### PR TITLE
Updated template syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,14 +57,14 @@ export default class MyButtonComponent extends Component {
 #### Using the component
 
 ```hbs
-<MyButton @primary=true>Primary</MyButton>
+<MyButton @primary={{true}}>Primary</MyButton>
 <MyButton>Normal</MyButton>
 ```
 
 ## Inline usage in templates
 
 ```hbs
-<div class={{ csz "text-align:center;"}}>Hello World</div>
+<div class={{csz "text-align:center;"}}>Hello World</div>
 ```
 
 Compatibility


### PR DESCRIPTION
I noticed that we passed the string `'true'` to `@primary`. I added double curly braces to pass the boolean instead.